### PR TITLE
Load additional info and show in header after loaded countries

### DIFF
--- a/ModuleExample.xcodeproj/project.pbxproj
+++ b/ModuleExample.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		E782EBBE2B9D91E8008B0B2B /* CountryListErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E782EBBA2B9D91E8008B0B2B /* CountryListErrorView.swift */; };
 		E782EBBF2B9D91E8008B0B2B /* CountryListLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E782EBBB2B9D91E8008B0B2B /* CountryListLoadingView.swift */; };
 		E782EBC12B9D9246008B0B2B /* CountryList+Screen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E782EBC02B9D9246008B0B2B /* CountryList+Screen.swift */; };
+		E782EBC32B9DA133008B0B2B /* UNService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E782EBC22B9DA133008B0B2B /* UNService.swift */; };
+		E782EBC52B9DA49B008B0B2B /* UNServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E782EBC42B9DA49B008B0B2B /* UNServiceMock.swift */; };
 		E7A622012B9C482300802183 /* CountryList+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A622002B9C482300802183 /* CountryList+Event.swift */; };
 		E7A622082B9C483000802183 /* CountryList+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A622022B9C483000802183 /* CountryList+State.swift */; };
 		E7A622092B9C483000802183 /* CountryList+Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7A622032B9C483000802183 /* CountryList+Action.swift */; };
@@ -52,6 +54,8 @@
 		E782EBBA2B9D91E8008B0B2B /* CountryListErrorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountryListErrorView.swift; sourceTree = "<group>"; };
 		E782EBBB2B9D91E8008B0B2B /* CountryListLoadingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CountryListLoadingView.swift; sourceTree = "<group>"; };
 		E782EBC02B9D9246008B0B2B /* CountryList+Screen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CountryList+Screen.swift"; sourceTree = "<group>"; };
+		E782EBC22B9DA133008B0B2B /* UNService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UNService.swift; sourceTree = "<group>"; };
+		E782EBC42B9DA49B008B0B2B /* UNServiceMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UNServiceMock.swift; sourceTree = "<group>"; };
 		E7A622002B9C482300802183 /* CountryList+Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CountryList+Event.swift"; sourceTree = "<group>"; };
 		E7A622022B9C483000802183 /* CountryList+State.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CountryList+State.swift"; sourceTree = "<group>"; };
 		E7A622032B9C483000802183 /* CountryList+Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CountryList+Action.swift"; sourceTree = "<group>"; };
@@ -127,6 +131,7 @@
 			children = (
 				E7A622132B9C4A8A00802183 /* CountryService.swift */,
 				E7A622112B9C4A8A00802183 /* CountriesResponse.swift */,
+				E782EBC22B9DA133008B0B2B /* UNService.swift */,
 				E7A622122B9C4A8A00802183 /* countries.json */,
 			);
 			path = Service;
@@ -141,6 +146,7 @@
 				E7A6222A2B9C4D4B00802183 /* CountryListActionCreatorTests.swift */,
 				E7A6222C2B9C4D5300802183 /* CountryListActionCreatorMock.swift */,
 				E7A622322B9C4DD500802183 /* CountryServiceMock.swift */,
+				E782EBC42B9DA49B008B0B2B /* UNServiceMock.swift */,
 			);
 			path = ModuleExampleTests;
 			sourceTree = "<group>";
@@ -289,6 +295,7 @@
 				E7A622292B9C4B9300802183 /* CountryListReducerTests.swift in Sources */,
 				E7A622332B9C4DD500802183 /* CountryServiceMock.swift in Sources */,
 				E7A6222B2B9C4D4B00802183 /* CountryListActionCreatorTests.swift in Sources */,
+				E782EBC52B9DA49B008B0B2B /* UNServiceMock.swift in Sources */,
 				E7A6222F2B9C4D5A00802183 /* CountryListStoreTests.swift in Sources */,
 				E7A6222D2B9C4D5300802183 /* CountryListActionCreatorMock.swift in Sources */,
 			);
@@ -310,6 +317,7 @@
 				E7A622082B9C483000802183 /* CountryList+State.swift in Sources */,
 				E7A6220F2B9C487E00802183 /* CountryList+Module.swift in Sources */,
 				E782EBC12B9D9246008B0B2B /* CountryList+Screen.swift in Sources */,
+				E782EBC32B9DA133008B0B2B /* UNService.swift in Sources */,
 				E782EBBD2B9D91E8008B0B2B /* CountryListView.swift in Sources */,
 				E7DCBFE32B4D460E00754DAD /* AppDelegate.swift in Sources */,
 				E77A5FB82B6A7C0400FE92B0 /* SceneDelegate.swift in Sources */,

--- a/ModuleExample/Module/CountryList+Action.swift
+++ b/ModuleExample/Module/CountryList+Action.swift
@@ -5,6 +5,7 @@ extension CountryList {
     case loadFirstPage
     case loadNextPage
     case didLoadPage(PageInfo)
+    case didLoadHeader(String?)
     case error(String)
   }
 
@@ -27,6 +28,8 @@ extension CountryList.Action: CustomDebugStringConvertible {
       description = "loadNextPage"
     case let .didLoadPage(pageInfo):
       description = "didLoadPage \(pageInfo)"
+    case .didLoadHeader:
+      description = "didLoadHeader"
     case .error:
       description = "error"
     }

--- a/ModuleExample/Module/CountryList+ActionCreator.swift
+++ b/ModuleExample/Module/CountryList+ActionCreator.swift
@@ -3,14 +3,18 @@ import Combine
 protocol CountryListActionCreatorProtocol {
   func loadFirstPage() -> AnyPublisher<CountryList.Action, Never>
   func loadNextPage(_ page: Int) -> AnyPublisher<CountryList.Action, Never>
+  func loadHeader(totalCount: Int) -> AnyPublisher<CountryList.Action, Never>
 }
 
 extension CountryList {
   final class ActionCreator: CountryListActionCreatorProtocol {
     private let countryService: CountryServiceProtocol
+    private let unService: UNServiceProtocol
 
-    init(countryService: CountryServiceProtocol) {
+    init(countryService: CountryServiceProtocol,
+         unService: UNServiceProtocol) {
       self.countryService = countryService
+      self.unService = unService
     }
 
     func loadFirstPage() -> AnyPublisher<Action, Never> {
@@ -22,6 +26,18 @@ extension CountryList {
     func loadNextPage(_ page: Int) -> AnyPublisher<Action, Never> {
       loadCountries(page: page)
         .prepend(.loadNextPage)
+        .eraseToAnyPublisher()
+    }
+
+    func loadHeader(totalCount: Int) -> AnyPublisher<Action, Never> {
+      unService.getUNCountriesCount()
+        .map { unCountriesCount in
+          let header = Adapter.adaptedHeader(totalCount, unCountriesCount)
+          return Action.didLoadHeader(header)
+        }
+        .catch { error in
+          Just(Action.error(Adapter.adaptedError(error)))
+        }
         .eraseToAnyPublisher()
     }
 

--- a/ModuleExample/Module/CountryList+Adapter.swift
+++ b/ModuleExample/Module/CountryList+Adapter.swift
@@ -9,6 +9,16 @@ extension CountryList {
         .map { ItemModel(id: $0.id, name: $0.name) }
     }
 
+    static func adaptedHeader(_ countriesCount: Int, _ unCountriesCount: Int) -> String? {
+      if countriesCount < unCountriesCount {
+        return "There are \(unCountriesCount - countriesCount) less countries than official UN countries..."
+      } else if countriesCount > unCountriesCount {
+        return "There are \(countriesCount - unCountriesCount) more countries than official UN countries..."
+      } else {
+        return nil
+      }
+    }
+
     static func adaptedError(_ error: Error) -> String {
       let description: String
       if error.localizedDescription.isEmpty {

--- a/ModuleExample/Module/CountryList+Event.swift
+++ b/ModuleExample/Module/CountryList+Event.swift
@@ -2,6 +2,7 @@ extension CountryList {
   enum Event: Equatable {
     case loadFirst
     case loadNext
+    case loadHeader(Int)
   }
 }
 
@@ -15,6 +16,8 @@ extension CountryList.Event: CustomDebugStringConvertible {
       description = "loadFirst"
     case .loadNext:
       description = "loadNext"
+    case .loadHeader:
+      description = "loadHeader"
     }
     return "Event \(description)"
   }

--- a/ModuleExample/Module/CountryList+Module.swift
+++ b/ModuleExample/Module/CountryList+Module.swift
@@ -4,7 +4,8 @@ import UIKit
 enum CountryList {
   static func createModule() -> UIViewController {
     let actionCreator = ActionCreator(
-      countryService: CountryService()
+      countryService: CountryService(),
+      unService: UNService()
     )
     let store = Store(actionCreator: actionCreator)
     let screen = Screen(store: store)

--- a/ModuleExample/Module/CountryList+Reducer.swift
+++ b/ModuleExample/Module/CountryList+Reducer.swift
@@ -10,6 +10,7 @@ extension CountryList.State {
       )
     case .loadNextPage:
       let listModel = CountryList.ListModel(
+        header: header,
         items: items,
         isLoadingNextPage: true
       )
@@ -19,12 +20,23 @@ extension CountryList.State {
       )
     case let .didLoadPage(pageInfo):
       let listModel = CountryList.ListModel(
+        header: header,
         items: items + pageInfo.items,
         isLoadingNextPage: false
       )
       let pagination = CountryList.Pagination(
         totalCount: pageInfo.totalCount,
         currentPage: pageInfo.page
+      )
+      return .init(
+        pagination: pagination,
+        screenState: .list(listModel)
+      )
+    case let .didLoadHeader(header):
+      let listModel = CountryList.ListModel(
+        header: header,
+        items: items,
+        isLoadingNextPage: isLoadingNextPage
       )
       return .init(
         pagination: pagination,

--- a/ModuleExample/Module/CountryList+State.swift
+++ b/ModuleExample/Module/CountryList+State.swift
@@ -19,6 +19,7 @@ extension CountryList {
   }
 
   struct ListModel: Equatable {
+    let header: String?
     let items: [ItemModel]
     let isLoadingNextPage: Bool
   }
@@ -49,6 +50,15 @@ extension CountryList.State {
       return model.isLoadingNextPage
     default:
       return false
+    }
+  }
+
+  var header: String? {
+    switch screenState {
+    case let .list(model):
+      return model.header
+    default:
+      return nil
     }
   }
 }

--- a/ModuleExample/Module/Service/CountryService.swift
+++ b/ModuleExample/Module/Service/CountryService.swift
@@ -14,7 +14,7 @@ final class CountryService: CountryServiceProtocol {
     return countries
   }()
 
-  private let scheduler = DispatchQueue(label: "service-queue")
+  private let scheduler = DispatchQueue(label: "co-service-queue")
 
   private let pageSize = 25
 

--- a/ModuleExample/Module/Service/UNService.swift
+++ b/ModuleExample/Module/Service/UNService.swift
@@ -1,0 +1,17 @@
+import Combine
+import Foundation
+
+protocol UNServiceProtocol {
+  func getUNCountriesCount() -> AnyPublisher<Int, Error>
+}
+
+final class UNService: UNServiceProtocol {
+  private let scheduler = DispatchQueue(label: "un-service-queue")
+
+  func getUNCountriesCount() -> AnyPublisher<Int, Error> {
+    Just(193)
+      .delay(for: .milliseconds(1000), scheduler: scheduler)
+      .setFailureType(to: Error.self)
+      .eraseToAnyPublisher()
+  }
+}

--- a/ModuleExample/Module/View/CountryListLoadingView.swift
+++ b/ModuleExample/Module/View/CountryListLoadingView.swift
@@ -15,6 +15,7 @@ extension CountryList.ListModel {
       CountryList.ItemModel(id: $0, name: "Placeholder")
     }
     return CountryList.ListModel(
+      header: nil,
       items: items,
       isLoadingNextPage: false
     )

--- a/ModuleExample/Module/View/CountryListView.swift
+++ b/ModuleExample/Module/View/CountryListView.swift
@@ -7,6 +7,12 @@ struct CountryListView: View {
   var body: some View {
     ScrollView {
       LazyVStack(spacing: 8) {
+        if let header = model.header {
+          Text(header)
+            .multilineTextAlignment(.center)
+            .foregroundStyle(.secondary)
+            .font(.subheadline)
+        }
         ForEach(model.items, id: \.id) { item in
           CountryListItemView(model: item)
             .frame(minHeight: 44)
@@ -48,23 +54,30 @@ private extension CountryList.ItemModel {
     CountryListView(model: .stub, onEvent: { _ in })
   }
 
+  #Preview("Header") {
+    CountryListView(model: .stubHeader, onEvent: { _ in })
+  }
+
   #Preview("Loading next") {
     CountryListView(model: .stubLoadingNext, onEvent: { _ in })
   }
 
   extension CountryList.ListModel {
     static var stub: Self {
-      .init(items: (0 ... 10).map { .stub($0) },
+      .init(header: nil,
+            items: (0 ... 10).map { .stub($0) },
             isLoadingNextPage: false)
     }
 
     static var stubHeader: Self {
-      .init(items: (0 ... 10).map { .stub($0) },
+      .init(header: "Header",
+            items: (0 ... 10).map { .stub($0) },
             isLoadingNextPage: false)
     }
 
     static var stubLoadingNext: Self {
-      .init(items: (0 ... 10).map { .stub($0) },
+      .init(header: nil,
+            items: (0 ... 10).map { .stub($0) },
             isLoadingNextPage: true)
     }
   }

--- a/ModuleExampleTests/CountryListActionCreatorMock.swift
+++ b/ModuleExampleTests/CountryListActionCreatorMock.swift
@@ -5,8 +5,9 @@ import Foundation
 struct CountryListActionCreatorMock: CountryListActionCreatorProtocol {
   var loadFirstPageResult: CountryList.Action?
   var loadNextPageResult: CountryList.Action?
-  
-  private let scheduler = DispatchQueue(label: "service-queue")
+  var loadHeaderResult: CountryList.Action?
+
+  private let scheduler = DispatchQueue(label: "action-creator-queue")
   
   func loadFirstPage() -> AnyPublisher<CountryList.Action, Never> {
     if let loadFirstPageResult {
@@ -23,6 +24,16 @@ struct CountryListActionCreatorMock: CountryListActionCreatorProtocol {
     if let loadNextPageResult {
       return Just(loadNextPageResult)
         .prepend(.loadNextPage)
+        .delay(for: .milliseconds(1), scheduler: scheduler)
+        .eraseToAnyPublisher()
+    }
+    assertionFailure("\(#function) called, but no result set up")
+    return Empty<CountryList.Action, Never>().eraseToAnyPublisher()
+  }
+  
+  func loadHeader(totalCount: Int) -> AnyPublisher<CountryList.Action, Never> {
+    if let loadHeaderResult {
+      return Just(loadHeaderResult)
         .delay(for: .milliseconds(1), scheduler: scheduler)
         .eraseToAnyPublisher()
     }

--- a/ModuleExampleTests/CountryListActionCreatorTests.swift
+++ b/ModuleExampleTests/CountryListActionCreatorTests.swift
@@ -15,8 +15,9 @@ final class CountryListActionCreatorTests: XCTestCase {
     countryService.countriesResult = .init(
       page: 0, totalCount: 0, countries: []
     )
+    let unService = UNServiceMock()
     let actionCreator = CountryList.ActionCreator(
-      countryService: countryService
+      countryService: countryService, unService: unService
     )
     let expectedActions: [CountryList.Action] = [
       .loadFirstPage,
@@ -43,8 +44,9 @@ final class CountryListActionCreatorTests: XCTestCase {
     countryService.countriesResult = .init(
       page: 1, totalCount: 0, countries: []
     )
+    let unService = UNServiceMock()
     let actionCreator = CountryList.ActionCreator(
-      countryService: countryService
+      countryService: countryService, unService: unService
     )
     let expectedActions: [CountryList.Action] = [
       .loadNextPage,
@@ -55,6 +57,35 @@ final class CountryListActionCreatorTests: XCTestCase {
     
     // When
     actionCreator.loadNextPage(1)
+      .sink { action in
+        receivedActions.append(action)
+      }
+      .store(in: &subscriptions)
+    
+    // Then
+    _ = XCTWaiter.wait(for: [XCTestExpectation()], timeout: 0.1)
+    XCTAssertEqual(expectedActions, receivedActions)
+  }
+  
+  func testLoadHeader() {
+    // Given
+    let countryService = CountryServiceMock()
+    let totalCount = 1
+    let unCount = 2
+    var unService = UNServiceMock()
+    unService.countResult = unCount
+
+    let actionCreator = CountryList.ActionCreator(
+      countryService: countryService, unService: unService
+    )
+    let expectedActions: [CountryList.Action] = [
+      .didLoadHeader(CountryList.Adapter.adaptedHeader(totalCount, unCount))
+    ]
+    
+    var receivedActions = [CountryList.Action]()
+    
+    // When
+    actionCreator.loadHeader(totalCount: totalCount)
       .sink { action in
         receivedActions.append(action)
       }

--- a/ModuleExampleTests/CountryListReducerTests.swift
+++ b/ModuleExampleTests/CountryListReducerTests.swift
@@ -21,13 +21,14 @@ final class CountryListReducerTests: XCTestCase {
     let loadedFirst = CountryList.State.initial.reduced(
       with: .didLoadPage(.init(page: 0, totalCount: 1, items: items))
     )
+    let loadedHeader = loadedFirst.reduced(with: .didLoadHeader(""))
     let expected = CountryList.State(
-      pagination: loadedFirst.pagination,
-      screenState: .list(.init(items: items, isLoadingNextPage: true))
+      pagination: loadedHeader.pagination,
+      screenState: .list(.init(header: "", items: items, isLoadingNextPage: true))
     )
     
     // When
-    let result = loadedFirst.reduced(with: .loadNextPage)
+    let result = loadedHeader.reduced(with: .loadNextPage)
     
     //Then
     XCTAssertEqual(expected, result)
@@ -39,7 +40,7 @@ final class CountryListReducerTests: XCTestCase {
     let loadingFirst = CountryList.State.initial.reduced( with: .loadFirstPage)
     let expected = CountryList.State(
       pagination: .init(totalCount: 1, currentPage: 0),
-      screenState: .list(.init(items: items, isLoadingNextPage: false))
+      screenState: .list(.init(header: nil, items: items, isLoadingNextPage: false))
     )
     
     // When
@@ -59,7 +60,8 @@ final class CountryListReducerTests: XCTestCase {
     let expected = CountryList.State(
       pagination: .init(totalCount: 2, currentPage: 1),
       screenState: .list(
-        .init(items: firstPageItems + secondPageItems,
+        .init(header: nil,
+              items: firstPageItems + secondPageItems,
               isLoadingNextPage: false)
       )
     )
@@ -70,6 +72,24 @@ final class CountryListReducerTests: XCTestCase {
         .init(page: 1, totalCount: 2, items: secondPageItems)
       )
     )
+    
+    //Then
+    XCTAssertEqual(expected, result)
+  }
+  
+  func testDidLoadHeader() {
+    // Given
+    let items = [CountryList.ItemModel(id: 0, name: "")]
+    let loadedFirst = CountryList.State.initial.reduced(
+      with: .didLoadPage(.init(page: 0, totalCount: 1, items: items))
+    )
+    let expected = CountryList.State(
+      pagination: .init(totalCount: 1, currentPage: 0),
+      screenState: .list(.init(header: "header", items: items, isLoadingNextPage: false))
+    )
+    
+    // When
+    let result = loadedFirst.reduced(with: .didLoadHeader("header"))
     
     //Then
     XCTAssertEqual(expected, result)

--- a/ModuleExampleTests/CountryListStoreStaticTests.swift
+++ b/ModuleExampleTests/CountryListStoreStaticTests.swift
@@ -41,4 +41,48 @@ final class CountryListStoreStaticTests: XCTestCase {
     // Then
     XCTAssertFalse(shouldInclude)
   }
+
+  func testExcludesDidLoadHeaderActionIfLoadingWholeScreen() {
+    // Given
+    let state = CountryList.State.initial.reduced(with: .loadFirstPage)
+    
+    // When
+    let shouldInclude = CountryList.Store.shouldIncludeAction(
+      .didLoadHeader(""), state: state
+    )
+    
+    // Then
+    XCTAssertFalse(shouldInclude)
+  }
+  
+  func testCreatesLoadHeaderEventAfterDidLoadPageActionIfNoHeader() {
+    // Given
+    let state = CountryList.State.initial.reduced(
+      with: .didLoadPage(.init(page: 0, totalCount: 1, items: []))
+    )
+    let expected = CountryList.Event.loadHeader(1)
+    
+    // When
+    let event = CountryList.Store.createEventWithAction(
+      .didLoadPage(.init(page: 0, totalCount: 1, items: [])), state: state
+    )
+    
+    // Then
+    XCTAssertEqual(expected, event)
+  }
+  
+  func testDoesntCreateLoadHeaderEventAfterDidLoadPageActionIfHeaderPresent() {
+    // Given
+    let state = CountryList.State.initial
+      .reduced(with: .didLoadPage(.init(page: 0, totalCount: 1, items: [])))
+      .reduced(with: .didLoadHeader(""))
+        
+    // When
+    let event = CountryList.Store.createEventWithAction(
+      .didLoadPage(.init(page: 0, totalCount: 1, items: [])), state: state
+    )
+    
+    // Then
+    XCTAssertNil(event)
+  }
 }

--- a/ModuleExampleTests/CountryListStoreTests.swift
+++ b/ModuleExampleTests/CountryListStoreTests.swift
@@ -9,7 +9,7 @@ final class CountryListStoreTests: XCTestCase {
     subscriptions = []
   }
   
-  func testStartsLoadingLoadsFirstPageWhenLoadFirst() {
+  func testStartsLoadingLoadsFirstPageLoadsHeaderWhenLoadFirst() {
     // Given
     var actionCreator = CountryListActionCreatorMock()
     let firstPage = 0
@@ -17,6 +17,8 @@ final class CountryListStoreTests: XCTestCase {
     actionCreator.loadFirstPageResult = .didLoadPage(
       .init(page: firstPage, totalCount: totalCount, items: [])
     )
+    let header = "Header"
+    actionCreator.loadHeaderResult = .didLoadHeader(header)
     
     // Expected states
     let initial = CountryList.State.initial
@@ -24,13 +26,14 @@ final class CountryListStoreTests: XCTestCase {
     let loadedFirst = loadingFirst.reduced(with:
         .didLoadPage(.init(page: firstPage, totalCount: totalCount, items: []))
     )
+    let loadedHeader = loadedFirst.reduced(with: .didLoadHeader(header))
     
     let store = CountryList.Store(
       initialState: initial, actionCreator: actionCreator
     )
     
     let expectedStates = [
-      initial, loadingFirst, loadedFirst
+      initial, loadingFirst, loadedFirst, loadedHeader
     ]
     
     var receivedStates = [CountryList.State]()
@@ -58,11 +61,12 @@ final class CountryListStoreTests: XCTestCase {
     actionCreator.loadNextPageResult = .didLoadPage(
       .init(page: nextPage, totalCount: totalCount, items: [])
     )
+    actionCreator.loadHeaderResult = .didLoadHeader("")
     
     // Expected states
     let loadedFirst = CountryList.State.initial.reduced(
       with: .didLoadPage(
-        .init(page: firstPage, 
+        .init(page: firstPage,
               totalCount: totalCount,
               items: [.init(id: 1, name: "")])
       )
@@ -71,12 +75,13 @@ final class CountryListStoreTests: XCTestCase {
     let loadedNext = loadingNext.reduced(
       with: .didLoadPage(.init(page: nextPage, totalCount: totalCount, items: []))
     )
+    let loadedHeader = loadedNext.reduced(with: .didLoadHeader(""))
     
     let store = CountryList.Store(
       initialState: loadedFirst, actionCreator: actionCreator
     )
     
-    let expectedStates = [loadedFirst, loadingNext, loadedNext]
+    let expectedStates = [loadedFirst, loadingNext, loadedNext, loadedHeader]
     
     var receivedStates = [CountryList.State]()
     
@@ -160,6 +165,7 @@ final class CountryListStoreTests: XCTestCase {
     // Given
     var actionCreator = CountryListActionCreatorMock()
     actionCreator.loadFirstPageResult = .didLoadPage(.init(page: 0, totalCount: 1, items: []))
+    actionCreator.loadHeaderResult = .didLoadHeader("")
     
     // Expected states
     let loadingNext = CountryList.State.initial.reduced(with: .loadNextPage)
@@ -167,7 +173,8 @@ final class CountryListStoreTests: XCTestCase {
     let loadedFirst = loadingFirst.reduced(
       with: .didLoadPage(.init(page: 0, totalCount: 1, items: []))
     )
-    let expectedStates = [loadingNext, loadingFirst, loadedFirst]
+    let loadedHeader = loadedFirst.reduced(with: .didLoadHeader(""))
+    let expectedStates = [loadingNext, loadingFirst, loadedFirst, loadedHeader]
     
     var receivedStates = [CountryList.State]()
     

--- a/ModuleExampleTests/UNServiceMock.swift
+++ b/ModuleExampleTests/UNServiceMock.swift
@@ -1,0 +1,17 @@
+import Combine
+import Foundation
+@testable import ModuleExample
+
+struct UNServiceMock: UNServiceProtocol {
+  var countResult: Int?
+  
+  func getUNCountriesCount() -> AnyPublisher<Int, Error> {
+    if let countResult {
+      return Just(countResult)
+        .setFailureType(to: Error.self)
+        .eraseToAnyPublisher()
+    }
+    assertionFailure("\(#function) called, but no result set up")
+    return Empty<Int, Error>().eraseToAnyPublisher()
+  }
+}


### PR DESCRIPTION
We have a requirement to load a header that shows whether the number of countries loaded from the countries API is the same as the official number of UN countries. We want to load that only once.

To achieve this, for every `Action` that goes through our `Store`, we add an `Event` if needed. In this case, we dispatch a 'load header' `Event` after the 'page did load' `Action`. This way, every time the page is loaded, a request for the count of UN countries is sent.

`Action.didLoadPage` -> `Event.loadHeader `-> `Action.didLoadHeader`